### PR TITLE
Add posibility to save and restore state

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ class MainActivity : AppCompatActivity() {
 
         choosePhotoHelper = ChoosePhotoHelper.with(this)
             .asFilePath()
+            .withState(savedInstanceState)
             .build(ChoosePhotoCallback {
                 Glide.with(this)
                     .load(it)
@@ -116,6 +117,10 @@ class MainActivity : AppCompatActivity() {
         choosePhotoHelper.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        choosePhotoHelper.onSaveInstanceState(outState)
+        super.onSaveInstanceState(outState)
+    }
 }
 ```
 


### PR DESCRIPTION
closes  #9 

This MR allows to use `onInstanceState` method to save state and restore it later using `withState`.
When used as shown in README it will work even when the phone is low on memory and system will recycle activity before choosing photo is done.

@aminography Let me know if you have any questions or suggestions.